### PR TITLE
Fix root permission with wiringPiSetup()

### DIFF
--- a/offsetIMU.cpp
+++ b/offsetIMU.cpp
@@ -11,7 +11,7 @@ using namespace std;
 int main(int argc, char **argv){
 
   int fd; 
-  wiringPiSetup();
+  wiringPiSetupSys();
   fd = wiringPiI2CSetup(0x68);
 
   int16_t InBuffer[9] = {0}; 

--- a/src/MPU9255_node.cpp
+++ b/src/MPU9255_node.cpp
@@ -16,7 +16,7 @@ int main(int argc, char **argv){
   ros::Publisher pub_mag = n.advertise<sensor_msgs::MagneticField>("imu/mag", 2);
   
 	int fd; 
-  wiringPiSetup();
+  wiringPiSetupSys();
   fd = wiringPiI2CSetup(0x68);
 	
 	if (fd == -1) {


### PR DESCRIPTION
This PR fixes the issue while executing the ROS node because `wiringPiSetup()` didn't have enough permissions to access to the hardware. The function was replaced by `wiringPiSetupSys()`.